### PR TITLE
Use functools.wraps to prevent the decorator from swallowing the view name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+
+[1.0.3] - 2019-09-12
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Use functools.wraps to prevent the decorator from swallowing the view name
+
 [1.0.2] - 2019-07-12
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/decorators.py
+++ b/edx_rbac/decorators.py
@@ -3,6 +3,8 @@ Taken from https://github.com/escodebar/django-rest-framework-rules/blob/master/
 """
 from __future__ import absolute_import, unicode_literals
 
+import functools
+
 import crum
 
 
@@ -16,6 +18,7 @@ def permission_required(*permissions, **decorator_kwargs):
     """
     def decorator(view):
         """Verify permissions decorator."""
+        @functools.wraps(view)
         def wrapped_view(self, request, *args, **kwargs):
             """Wrap for the view function."""
             fn = decorator_kwargs.get('fn', None)


### PR DESCRIPTION
Right now, it's impossible to distinguish views wrapped in `permission_required` in NewRelic from one another because they are all named `wrapped_view`. `functools.wraps` uses the `__name__` attribute from the underlying function (and should be used whenever you create a decorator).

FYI: @brittneyexline, @irfanuddinahmad