### PR TITLE
fix: get_role_auth_claim_for_user preserves role/context pair order.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,13 @@ Change Log
 Unreleased
 --------------------
 
-[2.0.0] - 2022-01-19
+[1.7.0]
+-------
+
+* fix: ``utils.get_role_auth_claim_for_user()`` now preserves the order of (role, context) pairs
+  as returned by the `get_assignment()` function.
+
+[1.6.0] - 2022-01-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Drop support for Django<3.2

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -2,6 +2,6 @@
 Library to help managing role based access controls for django apps.
 """
 
-__version__ = '1.6.0'
+__version__ = '1.7.0'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
``utils.get_role_auth_claim_for_user()`` now preserves the order of (role, context) pairs
as returned by the ``get_assignment()`` function.

[ENT-5700](https://openedx.atlassian.net/browse/ENT-5700)

This change is needed to support https://github.com/openedx/edx-enterprise/pull/1528