### PR TITLE
feat: add optional setting to "ignore" ``jwt.exceptions.InvalidTokenErrors``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 --------------------
 
+[1.10.0]
+-------
+* Optionally ignore and log ``jwt.exceptions.InvalidTokenErrors`` when decoding JWT from cookie.
+
 [1.9.0]
 -------
 * Add support for Python 3.11 & 3.12

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean compile_translations coverage diff_cover docs dummy_translations \
         extract_translations fake_translations help pii_check pull_translations push_translations \
-        quality requirements selfcheck test test-all upgrade validate check_keywords
+        quality requirements selfcheck test test-all upgrade validate check_keywords \
+	virtualenv virtualenv-activate
 
 .DEFAULT_GOAL := help
 
@@ -64,6 +65,9 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with 
 	grep -e "^django==" requirements/base.txt > requirements/django.txt
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
+
+virtualenv:
+	virtualenv venvs/edx-rbac
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -2,4 +2,4 @@
 Library to help managing role based access controls for django apps.
 """
 
-__version__ = '1.9.0'
+__version__ = '1.10.0'

--- a/edx_rbac/constants.py
+++ b/edx_rbac/constants.py
@@ -1,0 +1,16 @@
+"""
+All constants pertaining to the edx_rbac module.
+"""
+# The string denoting that a given role is applicable across all contexts
+ALL_ACCESS_CONTEXT = '*'
+
+# .. toggle_name: RBAC_IGNORE_INVALID_JWT_COOKIE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When true, causes instances of `jwt.exceptions.InvalidTokenError`
+#   to be ignored instead of raised in the `get_decoded_jwt()` utility function.
+#   Defaults to False for backward-compatibility purposes, but it's recommended
+#   to be set to True in dependent applications.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2024-08-19
+IGNORE_INVALID_JWT_COOKIE_SETTING = 'RBAC_IGNORE_INVALID_JWT_COOKIE'

--- a/edx_rbac/models.py
+++ b/edx_rbac/models.py
@@ -15,7 +15,7 @@ class UserRoleAssignmentCreator(ModelBase):
     The model extending UserRoleAssignment should get a foreign key to a model that is a subclass of UserRole.
     """
 
-    def __new__(mcs, name, bases, attrs):    # pylint: disable=arguments-differ
+    def __new__(mcs, name, bases, attrs):
         """
         Override to dynamically create foreign key for objects begotten from abstract class.
         """


### PR DESCRIPTION
We get sporadic instances of this error that we'd prefer to just ignore as to not clutter our monitoring tools.

This can be used by setting `IGNORE_INVALID_JWT_COOKIE` to True in applications that install this library.