### PR TITLE
build: fix changelog RST syntax so pypi publish works

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Unreleased
 --------------------
 
 [1.10.0]
--------
+--------
 * Optionally ignore and log ``jwt.exceptions.InvalidTokenErrors`` when decoding JWT from cookie.
 
 [1.9.0]


### PR DESCRIPTION
Fixes this busted action: https://github.com/openedx/edx-rbac/actions/runs/10460569983/job/28967019184
```
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 96: Warning: Title underline too short.                           
                                                                                
         [1.10.0]                                                               
         -------      
```