### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.11', '3.12']
         toxenv: [quality, django42, check_keywords]
     steps:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     push:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       steps:
         - name: Checkout
           uses: actions/checkout@v4


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/edx-rbac/issues/315
