### PR TITLE
chore: ENT-11628 Add tpa_org_allowlist_admin permission

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -49,6 +49,7 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     'enterprise_leaner': [],
     'coupon-manager': ['coupon-management'],
     'enterprise_openedx_operator': ['enterprise_data_admin'],
+    'tpa_org_allowlist_admin': ['tpa_org_allowlist_admin'],
 }
 
 SYSTEM_WIDE_ROLE_CLASSES = [

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -78,16 +78,9 @@ class TestPermissionRequiredForListingMixin(TestCase):
     """
     Tests for the `PermissionRequiredForListingMixin` mixin.
 
-    Note that our test_settings.py file defines:
-
-    SYSTEM_TO_FEATURE_ROLE_MAPPING = {
-        'enterprise_admin': ['coupon-management', 'data_api_access'],
-        'enterprise_leaner': [],
-        'coupon-manager': ['coupon-management'],
-        'enterprise_openedx_operator': ['enterprise_data_admin'],
-    }
-
-    So there is a 'coupon-manager' system-wide role which includes the
+    Note that our test_settings.py file defines SYSTEM_TO_FEATURE_ROLE_MAPPING.
+    Among other entries, it maps 'coupon-manager' to ['coupon-management'],
+    so there is a 'coupon-manager' system-wide role which includes the
     'coupon-management' feature role in this particular system.
     """
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,16 +41,9 @@ class TestUtils(TestCase):
     """
     TestUtils tests.
 
-    Note that our test_settings.py file defines:
-
-    SYSTEM_TO_FEATURE_ROLE_MAPPING = {
-        'enterprise_admin': ['coupon-management', 'data_api_access'],
-        'enterprise_leaner': [],
-        'coupon-manager': ['coupon-management'],
-        'enterprise_openedx_operator': ['enterprise_data_admin'],
-    }
-
-    So there is a 'coupon-manager' system-wide role which includes the
+    Note that our test_settings.py file defines SYSTEM_TO_FEATURE_ROLE_MAPPING.
+    Among other entries, it maps 'coupon-manager' to ['coupon-management'],
+    so there is a 'coupon-manager' system-wide role which includes the
     'coupon-management' feature role in this particular system.
     """
 


### PR DESCRIPTION
Adds an admin permission tpa_org_allowlist_admin for integrated channels API.
https://2u-internal.atlassian.net/browse/ENT-11628